### PR TITLE
Release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `Laravel Silent Authentication` will be documented in thi
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v0.1.1] (2019-10-23)
+
+### Added
+
+- Allow `5.8.*` and `^6.0` of `illuminate/auth`
+
 ## [v0.1.0] (2019-02-09)
 
 ### Added
@@ -12,3 +18,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added config file that allows people to customize/disable the default scaffholding
 - Added `SessionGuard` that extends the original class but uses the `SilentAuthentication` trait
 - Added `SilentAuthentication` trait which will contain the methods to silently authenticate users
+
+[v0.1.1]: https://github.com/cyrildewit/eloquent-viewable/compare/v0.1.0...v0.1.1

--- a/composer.json
+++ b/composer.json
@@ -29,12 +29,12 @@
     ],
     "require": {
         "php": "^7.1",
-        "illuminate/auth": "5.5.*|5.6.*|5.7.*"
+        "illuminate/auth": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0",
-        "phpunit/phpunit": "^6.5|^7.0"
+        "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0|~3.8.0|^4.0",
+        "phpunit/phpunit": "^6.5|^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
### Added

- Allow `5.8.*` and `^6.0` of `illuminate/auth`
